### PR TITLE
Windows Phone 10 bug fix

### DIFF
--- a/jquery.ultimate-smartbanner.js
+++ b/jquery.ultimate-smartbanner.js
@@ -19,12 +19,12 @@
         || navigator.userAgent.match(/Version/i) == null
       )
         this.type = 'ios'; // Check webview and native smart banner support (iOS 6+)
+    } else if (navigator.userAgent.match(/Windows Phone/i) != null) {
+      this.type = 'windows-phone'
     } else if (navigator.userAgent.match(/Android/i) != null) {
       this.type = 'android'
     } else if (navigator.userAgent.match(/Windows NT 6.2/i) != null) {
       this.type = 'windows'
-    } else if (navigator.userAgent.match(/Windows Phone/i) != null) {
-      this.type = 'windows-phone'
     }
 
     // Don't show banner if device isn't iOS or Android, website is loaded in app or user dismissed banner


### PR DESCRIPTION
the bug:
when the user is Windows Phone 10 user,
his UserAgent contains both "Windows Phone 10" and "Android.." strings
so your code assigns 'android' for the type instead of 'windows-phone'.
the exact UA is in this form : 
Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; DEVICE INFO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.

and the google play store banner is shown (which is wrong).

the fix: 
changing the IF order fixes this bug as the windows phone is detected first.
